### PR TITLE
update to 1.6.640 and GOG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 vcpkg_installed/
 .idea/
 include/steam/
+.vs/
+package/

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -82,8 +82,9 @@ EXTERN_C [[maybe_unused]] __declspec(dllexport) bool SKSEAPI SKSEPlugin_Load(con
 EXTERN_C [[maybe_unused]] __declspec(dllexport) constinit auto SKSEPlugin_Version = []() noexcept {
 	SKSE::PluginVersionData v;
 	v.PluginName("PluginName");
-	v.PluginVersion({ 1, 0, 0, 0 });
+	v.PluginVersion({ 1, 1, 0, 0 });
 	v.UsesAddressLibrary(true);
+	v.HasNoStructUse(true);
 	return v;
 }();
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,9 +1,16 @@
 {
+	
+	    "default-registry": {
+        "kind": "git",
+        "repository": "https://github.com/microsoft/vcpkg.git",
+        "baseline": "cc288af760054fa489574bd8e22d05aa8fa01e5c"
+    },
+	
     "registries": [
         {
             "kind": "git",
             "repository": "https://gitlab.com/colorglass/vcpkg-colorglass",
-            "baseline": "7abd808aa0ae8d65710f3a9f77f15937530309aa",
+            "baseline": "6fb127f7d425ae3cf3fab0f79005d907c885c0d8",
             "packages": [
                 "articuno",
                 "bethesda-skyrim-scripts",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,7 +13,8 @@
                 "commonlibsse-ng",
                 "nlohmann-json",
                 "simpleini",
-                "magic-enum"
+                "magic-enum",
+				"rsm-binary-io"
             ]
         }
     },


### PR DESCRIPTION
changed vcpkg.json to include rsm-binary-io, don't know if it's really needed